### PR TITLE
added override to avoid disk space issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,8 @@ RUN apt-get update && apt-get install -y boinc-client
 # Set working directory
 WORKDIR /var/lib/boinc-client
 
+# Copy override prefs so we don't run out of space in our image
+COPY global_prefs_override.xml /etc/boinc-client/global_prefs_override.xml
+
 # Run BOINC by default. Expects env vars for url and account key
 CMD /etc/init.d/boinc-client start; sleep 5; /usr/bin/boinccmd --project_attach ${boincurl} ${boinckey}; tail -f /var/lib/boinc-client/std*.txt

--- a/global_prefs_override.xml
+++ b/global_prefs_override.xml
@@ -1,0 +1,9 @@
+<!--
+     This configuration file global_prefs_override.xml for the BOINC core client
+can be used to override global preferences locally. For a complete list of
+all preferences which can be overridden see:
+http://boinc.berkeley.edu/trac/wiki/PrefsOverride
+-->
+<global_preferences>
+<disk_max_used_pct>80</disk_max_used_pct>
+</global_preferences>


### PR DESCRIPTION
Noticed that my image - which defaults to 10G of disk space - would fill up after a couple days of runtime, resulting in stalled jobs. Added a global_prefs_override.xml file to limit disk utilization to 80% of space available.

```
07-Apr-2020 22:30:39 [---] Reading preferences override file
07-Apr-2020 22:30:39 [---] Preferences:
07-Apr-2020 22:30:39 [---]    max memory usage when active: 15950.61 MB
07-Apr-2020 22:30:39 [---]    max memory usage when idle: 28711.10 MB
07-Apr-2020 22:30:39 [---]    max disk usage: 7.30 GB
07-Apr-2020 22:30:39 [---]    don't use GPU while active
07-Apr-2020 22:30:39 [---]    suspend work if non-BOINC CPU load exceeds 25%
```